### PR TITLE
Add support for `x86_64-windows-gnu` and `x86_64-windows-msvc`. Add support for Zig 0.12.0 to 0.13.0, drop support for 0.11.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 zig-cache/
+.zig-cache/
 zig-out/

--- a/build.zig
+++ b/build.zig
@@ -17,9 +17,6 @@ pub fn build(b: *std.Build) !void {
     const use_double_precision = b.option(bool, "double", "All data will be stored as double values") orelse false;
     const assimp = b.dependency("assimp", .{});
 
-    const joined_target_str = try std.mem.concat(b.allocator, u8, &.{ @tagName(target.result.cpu.arch), "_", @tagName(target.result.os.tag), "_", @tagName(target.result.abi) });
-    defer b.allocator.free(joined_target_str);
-
     const lib = b.addStaticLibrary(.{
         .name = "assimp",
         .optimize = optimize,
@@ -30,7 +27,6 @@ pub fn build(b: *std.Build) !void {
         lib.defineCMacro("_WINDOWS", null);
         lib.defineCMacro("_WIN32", null);
         lib.defineCMacro("OPENDDL_STATIC_LIBARY", null);
-        lib.defineCMacro("ASSIMP_IMPORTER_GLTF_USE_OPEN3DGC", "1");
     }
 
     lib.linkLibC();
@@ -140,29 +136,46 @@ pub fn build(b: *std.Build) !void {
         lib.defineCMacro(define_exporter, null);
     }
 
-    const assimp_lib_path = try std.fs.path.join(b.allocator, &.{ joined_target_str, "assimp.lib" });
-    defer b.allocator.free(assimp_lib_path);
-    const libArtifact = b.addInstallLibFile(lib.getEmittedBin(), assimp_lib_path);
-    libArtifact.step.dependOn(&lib.step);
-    b.getInstallStep().dependOn(&libArtifact.step);
+    b.installArtifact(lib);
 
-    if (lib.producesPdbFile()) {
-        const assimp_pdb_path = try std.fs.path.join(b.allocator, &.{ joined_target_str, "assimp.pdb" });
-        defer b.allocator.free(assimp_pdb_path);
-        const pdbArtifact = b.addInstallLibFile(lib.getEmittedPdb(), assimp_pdb_path);
-        pdbArtifact.step.dependOn(&lib.step);
-        b.getInstallStep().dependOn(&pdbArtifact.step);
+    const example_cpp = b.addExecutable(.{
+        .name = "static-example-cpp",
+        .target = target,
+        .optimize = optimize,
+    });
+    example_cpp.addCSourceFiles(.{
+        .files = &[_][]const u8{"src/example.cpp"},
+        .flags = &[_][]const u8{"-std=c++17"},
+    });
+    example_cpp.linkLibrary(lib);
+    example_cpp.linkLibC();
+    if (target.result.abi != .msvc) {
+        example_cpp.linkLibCpp();
     }
+    example_cpp.addIncludePath(assimp.path("include"));
+    if (target.result.os.tag == .windows) {
+        example_cpp.defineCMacro("_WINDOWS", null);
+        example_cpp.defineCMacro("_WIN32", null);
+    }
+    b.installArtifact(example_cpp);
 
-    const zig_assimp_license_target = try std.fs.path.join(b.allocator, &.{ joined_target_str, "ZIG_ASSIMP_LICENSE" });
-    defer b.allocator.free(zig_assimp_license_target);
-    b.installLibFile("LICENCE", zig_assimp_license_target);
-
-    const assimp_license_target = try std.fs.path.join(b.allocator, &.{ joined_target_str, "ASSIMP_LICENSE" });
-    defer b.allocator.free(assimp_license_target);
-    const addLicense = b.addInstallLibFile(assimp.path("LICENSE"), assimp_license_target);
-    addLicense.step.dependOn(&lib.step);
-    b.getInstallStep().dependOn(&addLicense.step);
+    const example_c = b.addExecutable(.{
+        .name = "static-example-c",
+        .target = target,
+        .optimize = optimize,
+    });
+    example_c.addCSourceFiles(.{
+        .files = &[_][]const u8{"src/example.c"},
+        .flags = &[_][]const u8{"-std=c99"},
+    });
+    example_c.linkLibrary(lib);
+    example_c.linkLibC();
+    example_c.addIncludePath(assimp.path("include"));
+    if (target.result.os.tag == .windows) {
+        example_c.defineCMacro("_WINDOWS", null);
+        example_c.defineCMacro("_WIN32", null);
+    }
+    b.installArtifact(example_c);
 }
 
 const unsupported_formats = [_][]const u8{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,7 +4,7 @@
     .paths = .{
         "build.zig",
         "build.zig.zon",
-        "LICECE",
+        "LICENCE",
         "README.md",
         "include",
         "src",

--- a/include/zconf.h
+++ b/include/zconf.h
@@ -8,7 +8,6 @@
 #ifndef ZCONF_H
 #define ZCONF_H
 /* #undef Z_PREFIX */
-#define Z_HAVE_UNISTD_H
 
 /*
  * If you *really* need a unique prefix for all types and library functions,
@@ -433,6 +432,10 @@ typedef uLong FAR uLongf;
    typedef unsigned long z_crc_t;
 #endif
 
+#if !defined(WINDOWS)
+#  define HAVE_UNISTD_H
+#endif
+
 #ifdef HAVE_UNISTD_H    /* may be set to #if 1 by ./configure */
 #  define Z_HAVE_UNISTD_H
 #endif
@@ -469,11 +472,18 @@ typedef uLong FAR uLongf;
 #  undef _LARGEFILE64_SOURCE
 #endif
 
-#if defined(__WATCOMC__) && !defined(Z_HAVE_UNISTD_H)
-#  define Z_HAVE_UNISTD_H
+#ifndef Z_HAVE_UNISTD_H
+#  ifdef __WATCOMC__
+#    define Z_HAVE_UNISTD_H
+#  endif
+#endif
+#ifndef Z_HAVE_UNISTD_H
+#  if defined(_LARGEFILE64_SOURCE) && !defined(_WIN32)
+#    define Z_HAVE_UNISTD_H
+#  endif
 #endif
 #ifndef Z_SOLO
-#  if defined(Z_HAVE_UNISTD_H) || defined(_LARGEFILE64_SOURCE)
+#  if defined(Z_HAVE_UNISTD_H)
 #    include <unistd.h>         /* for SEEK_*, off_t, and _LFS64_LARGEFILE */
 #    ifdef VMS
 #      include <unixio.h>       /* for off_t */


### PR DESCRIPTION
Should resolve this issue:
https://github.com/ikskuh/zig-assimp/issues/10

As well as adding support for building on windows.